### PR TITLE
chore: 修复Turbo Service github action执行报错 #7005

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.18.1
+          go-version: 1.17.11
       - uses: actions/checkout@v2
       - run: make clean all
         working-directory: src/agent/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.18.1
+          go-version: 1.17.11
       - uses: actions/checkout@v2
       - run: make clean all
         working-directory: src/agent/


### PR DESCRIPTION
go 版本降级，兼容低版本的macos